### PR TITLE
Bump minor versions for native dependencies

### DIFF
--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -10,12 +10,12 @@ apply plugin: 'de.undercouch.download'
 
 apply from: 'natives.gradle'
 
-ext.opusVersion = '1.3'
-ext.mpg123Version = '1.25.10'
-ext.oggVersion = '1.3.3'
-ext.vorbisVersion = '1.3.6'
+ext.opusVersion = '1.3.1'
+ext.mpg123Version = '1.25.13'
+ext.oggVersion = '1.3.5'
+ext.vorbisVersion = '1.3.7'
 ext.sampleRateVersion = '0.1.9'
-ext.fdkAacVersion = '2.0.0'
+ext.fdkAacVersion = '2.0.2'
 
 task load { doLast {
   if (!file("$projectDir/samplerate/src").exists()) {


### PR DESCRIPTION
Aims to accomplish what #2 does but in a more compatible manner.
Tested and builds on my fork.

### Opus `1.3` -> `1.3.1` notable changes:
- Nothing really noteworthy that Lavaplayer is likely to leverage, so bumping this is somewhat redundant, but no harm done in having it pinned at latest minor version.

### mpg123 `1.25.10` -> `1.25.13` notable changes:
<details>

- Fix out-of-bounds reads in ID3 parser for unsynced frames.
- Fix out-of-bounds read for RVA2 frames with non-delimited identifier.
- Fix implementation-defined parsing of RVA2 values.
- Fix undefined parsing of APE header for skipping. Also prevent endless loop on premature end of supposed APE header.
- Fix an out-of-bounds read of maximal two bytes for truncated RVA2 frames.
- Fix an invalid write of one zero byte for empty ID3v2 frames that demand de-unsyncing.
- Reset the flag for having a frame to decode before trying to parse a new one. This prevents very unkind behaviour (crashes) when combining mpg123_scan() with decoding later on for damaged streams that have a mixture of different MPEG versions.
</details>

### Ogg `1.3.3` -> `1.3.5` notable changes:
<details>

- Fix unsigned typedef problem on macOS.
- Fix overflow check in ogg_sync_buffer.
- Faster slice-by-8 CRC32 implementation.
</details>

### Vorbis `1.3.6` -> `1.3.7` notable changes:
<details>

- Fix CVE-2018-10393 - out-of-bounds read encoding very low sample rates.
- Fix CVE-2017-14160 - out-of-bounds read encoding very low sample rates.
- Fix CVE-2018-10392 - out-of-bounds access encoding invalid channel count.
- Fix handling invalid bytes per sample arguments.
- Fix handling invalid channel count arguments.
- Fix invalid free on seek failure.
- Fix negative shift reading blocksize.
- Fix accepting unreasonable float32 values.
</details>

### fdkaac `2.0.0` -> `2.0.2` notable changes:
<details>

 - Minor upstream updates
 - Lots of upstream and local fuzzing fixes
 - Minor release with a number of crash/fuzz fixes, primarily for the decoder
 </details>

